### PR TITLE
Fixed sm hash calculation.

### DIFF
--- a/fsbl/main.c
+++ b/fsbl/main.c
@@ -406,7 +406,7 @@ typedef unsigned char byte;
 // Sanctum header fields in DRAM
 extern byte sanctum_dev_public_key[32];
 extern byte sanctum_dev_secret_key[64];
-unsigned int sanctum_sm_size = 0x2ff000;
+unsigned int sanctum_sm_size = 0x1ff000;
 extern byte sanctum_sm_hash[64];
 extern byte sanctum_sm_public_key[32];
 extern byte sanctum_sm_secret_key[64];


### PR DESCRIPTION
With the commit 3fe4313, the starting address of the payload was changed, so it was calculating the hash crossing the boundary of sm area to payload area.
The hash value was changing every time when having the new kernel.
Fixing the length accordingly.
